### PR TITLE
Multiple namenode support with failover

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ os:
 language: go
 go_import_path: github.com/colinmarc/hdfs
 go: 1.7
+sudo: required
 before_install:
 - git clone https://github.com/sstephenson/bats $HOME/bats
 - mkdir -p $HOME/bats/build
 - "$HOME/bats/install.sh $HOME/bats/build"
 - export PATH="$PATH:$HOME/bats/build/bin"
+- sudo apt-get update && sudo apt-get install libprotobuf-dev protobuf-compiler -y
 env:
 - HADOOP_DISTRO=cdh
 - HADOOP_DISTRO=hdp

--- a/client.go
+++ b/client.go
@@ -16,6 +16,13 @@ type Client struct {
 	defaults *hdfs.FsServerDefaultsProto
 }
 
+// ClientOptions represents the configurable options for a client.
+type ClientOptions struct {
+	Addresses []string
+	Namenode  *rpc.NamenodeConnection
+	User      string
+}
+
 // Username returns the value of HADOOP_USER_NAME in the environment, or
 // the current system user if it is not set.
 func Username() (string, error) {
@@ -30,53 +37,79 @@ func Username() (string, error) {
 	return currentUser.Username, nil
 }
 
+// NewClient returns a connected Client for the given options, or an error if
+// the client could not be created.
+func NewClient(options ClientOptions) (*Client, error) {
+	var err error
+
+	if options.User == "" {
+		options.User, err = Username()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if options.Addresses == nil || len(options.Addresses) == 0 {
+		options.Addresses, err = getNameNodeFromConf()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if options.Namenode == nil {
+		options.Namenode, err = rpc.NewNamenodeConnectionWithOptions(
+			rpc.NamenodeConnectionOptions{
+				Addresses: options.Addresses,
+				User:      options.User,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Client{namenode: options.Namenode}, nil
+}
+
 // New returns a connected Client, or an error if it can't connect. The user
 // will be the user the code is running under. If address is an empty string
 // it will try and get the namenode address from the hadoop configuration
 // files.
 func New(address string) (*Client, error) {
-	username, err := Username()
-	if err != nil {
-		return nil, err
+	options := ClientOptions{}
+
+	if address != "" {
+		options.Addresses = []string{address}
 	}
 
-	if address == "" {
-		var nnErr error
-		address, nnErr = getNameNodeFromConf()
-		if nnErr != nil {
-			return nil, nnErr
-		}
-	}
-
-	return NewForUser(address, username)
+	return NewClient(options)
 }
 
-// getNameNodeFromConf return a datanode from the system hadoop configuration
-func getNameNodeFromConf() (string, error) {
+// getNameNodeFromConf returns namenodes from the system Hadoop configuration.
+func getNameNodeFromConf() ([]string, error) {
 	hadoopConf := LoadHadoopConf("")
 
 	namenodes, nnErr := hadoopConf.Namenodes()
 	if nnErr != nil {
-		return "", nnErr
+		return nil, nnErr
 	}
-	return namenodes[0], nil
+	return namenodes, nil
 }
 
 // NewForUser returns a connected Client with the user specified, or an error if
 // it can't connect.
 func NewForUser(address string, user string) (*Client, error) {
-	namenode, err := rpc.NewNamenodeConnection(address, user)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Client{namenode: namenode}, nil
+	return NewClient(ClientOptions{
+		Addresses: []string{address},
+		User:      user,
+	})
 }
 
 // NewForConnection returns Client with the specified, underlying rpc.NamenodeConnection.
 // You can use rpc.WrapNamenodeConnection to wrap your own net.Conn.
 func NewForConnection(namenode *rpc.NamenodeConnection) *Client {
-	return &Client{namenode: namenode}
+	client, _ := NewClient(ClientOptions{Namenode: namenode})
+	return client
 }
 
 // ReadFile reads the file named by filename and returns the contents.

--- a/client_test.go
+++ b/client_test.go
@@ -75,6 +75,22 @@ func assertPathError(t *testing.T, err error, op, path string, wrappedErr error)
 	require.Equal(t, expected, err)
 }
 
+func TestNewWithMultipleNodes(t *testing.T) {
+	nn := os.Getenv("HADOOP_NAMENODE")
+	if nn == "" {
+		t.Fatal("HADOOP_NAMENODE not set")
+	}
+	_, err := NewClient(ClientOptions{
+		Addresses: []string{"localhost:80", nn},
+	})
+	assert.Nil(t, err)
+}
+
+func TestNewWithFailingNode(t *testing.T) {
+	_, err := New("localhost:80")
+	assert.NotNil(t, err)
+}
+
 func TestReadFile(t *testing.T) {
 	client := getClient(t)
 

--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -117,6 +117,7 @@ func (c *NamenodeConnection) resolveConnection() error {
 		return nil
 	}
 
+	var err error
 	for _, host := range c.hostList {
 		if c.host == host {
 			continue
@@ -126,7 +127,6 @@ func (c *NamenodeConnection) resolveConnection() error {
 			continue
 		}
 
-		var err error
 		c.host = host
 		c.conn, err = net.DialTimeout("tcp", host.address, connectTimeout)
 		if err != nil {
@@ -144,7 +144,7 @@ func (c *NamenodeConnection) resolveConnection() error {
 	}
 
 	if c.conn == nil {
-		return fmt.Errorf("No available namenodes")
+		return fmt.Errorf("no available namenodes: %s", err.Error())
 	}
 
 	return nil

--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -31,8 +31,8 @@ type NamenodeConnection struct {
 	currentRequestID int
 	user             string
 	conn             net.Conn
-	host             *host
-	hostList         []*host
+	host             *namenodeHost
+	hostList         []*namenodeHost
 	reqLock          sync.Mutex
 }
 
@@ -67,7 +67,7 @@ func (err *NamenodeError) Error() string {
 	return s
 }
 
-type host struct {
+type namenodeHost struct {
 	address     string
 	lastFailure time.Time
 }
@@ -88,9 +88,9 @@ func NewNamenodeConnection(address string, user string) (*NamenodeConnection, er
 // the given options and performs an initial handshake.
 func NewNamenodeConnectionWithOptions(options NamenodeConnectionOptions) (*NamenodeConnection, error) {
 	// Build the list of hosts to be used for failover.
-	hostList := make([]*host, len(options.Addresses))
+	hostList := make([]*namenodeHost, len(options.Addresses))
 	for i, addr := range options.Addresses {
-		hostList[i] = &host{address: addr}
+		hostList[i] = &namenodeHost{address: addr}
 	}
 
 	// The ClientID is reused here both in the RPC headers (which requires a

--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -14,12 +14,13 @@ import (
 )
 
 const (
-	rpcVersion           = 0x09
-	serviceClass         = 0x0
-	authProtocol         = 0x0
-	protocolClass        = "org.apache.hadoop.hdfs.protocol.ClientProtocol"
-	protocolClassVersion = 1
-	handshakeCallID      = -3
+	rpcVersion            = 0x09
+	serviceClass          = 0x0
+	authProtocol          = 0x0
+	protocolClass         = "org.apache.hadoop.hdfs.protocol.ClientProtocol"
+	protocolClassVersion  = 1
+	handshakeCallID       = -3
+	standbyExceptionClass = "org.apache.hadoop.ipc.StandbyException"
 )
 
 const backoffDuration = time.Second * 5
@@ -188,7 +189,8 @@ R:
 	err = c.readResponse(method, resp)
 	if err != nil {
 		if nerr, ok := err.(*NamenodeError); ok {
-			if nerr.Exception != "org.apache.hadoop.ipc.StandbyException" {
+			// if it's not a standby exception, we won't retry
+			if nerr.Exception != standbyExceptionClass {
 				return err
 			}
 		}


### PR DESCRIPTION
This changeset is borrow from @itszootime's latest change, it's an unapproved pull request, however, already tested by Richard Jones in his production cluster.

Mainly changes for this commitment:
1. Enable client to accept multiple namenode at the same time
2. Fix the bug on namenode connection: which originally only returns first name node
3. Add retry behaviour

After this change, the usage will be changed to:
1. set HADOOP_HOME and HADOOP_CONF_DIR
2. client, _ := hdfs.New("")

Then others looks the same

Testing scenario for this change will be:
1. hdfsClient can connect to HA enabled cluster when configuration is provided
2. hdfsClient can connect to hdfs cluster via specifying namenode
3. hdfsClient can handle name-node switch under below cases:
    a. each single command: ls/copyFromLocal/cp/copyToLocal/chmod/chown/append/
    b. big sizes of file uploading/downloading

